### PR TITLE
feat: add DR7 (IPQ5322) SGMII+ 2.5G support

### DIFF
--- a/docs/sfp-sgmiiplus-dr7.md
+++ b/docs/sfp-sgmiiplus-dr7.md
@@ -1,0 +1,253 @@
+# sfp-sgmiiplus-dr7 (HSGMII on Dream Router 7)
+
+**Script:** [`scripts/20-sfp-sgmiiplus-dr7.sh`](../scripts/20-sfp-sgmiiplus-dr7.sh) (eth4 / SFP port)
+**Module:** [`modules/force-uniphy1-sgmiiplus-dr7/`](../modules/force-uniphy1-sgmiiplus-dr7/)
+**Compatibility:** UniFi Dream Router 7 (DR7, IPQ5322, kernel 5.4.213-ui-ipq5322-wireless)
+**Risk level:** Medium - kernel module, modifies SSDK internal state
+**Status:** Beta - module loads correctly, clock/SerDes/speed reporting verified at 2.5G. Full end-to-end GPON throughput test pending (fiber connection not yet active; expected ~2 weeks).
+**Also known as:** HSGMII (Intel/Lantiq/MaxLinear terminology for the same 2.5G SerDes mode)
+
+---
+
+## Background / Porting notes
+
+This module is a port of the UCG-Fiber / UXG-Fiber `force_uniphy1_sgmiiplus` module (IPQ9574)
+to the **UniFi Dream Router 7** (IPQ5322). The IPQ5322 uses the same QCA-SSDK and the same
+kernel version (5.4.213), but has a different internal port topology that required non-trivial
+changes to make the port work correctly.
+
+The key differences discovered during porting are documented in the table below and explained
+in detail in the rest of this file.
+
+---
+
+## Problem
+
+Same root cause as the UCG-Fiber / UXG-Fiber: the SSDK's SFP EEPROM validation blocks the
+speed change to 2.5G, and the MAC sync polling loop continuously resets uniphy1 back to
+SGMII 1G.
+
+On the DR7 specifically, the MAC sync loop resets uniphy1 **every ~5 seconds** via
+`__adpt_hppe_uniphy_sgmii_mode_set` (visible in dmesg). This is more aggressive than on the
+UCG/UXG-Fiber and is caused by the RTL8261 PHY in the SFP port triggering repeated
+re-initialization. Without the bitmap exclusion, any 2.5G SerDes configuration is overwritten
+within seconds.
+
+---
+
+## Key differences from UCG-Fiber / UXG-Fiber
+
+| Parameter | UCG/UXG-Fiber (IPQ9574) | DR7 (IPQ5322) |
+|---|---|---|
+| Kernel | 5.4.213-ui-ipq9574 | 5.4.213-ui-ipq5322-wireless |
+| SFP interface | eth6 (Port 7) / eth5 (Port 6) | **eth4** |
+| Uniphy index | 1 (eth6) / 2 (eth5) | **1** |
+| SSDK port ID | 5 (eth6) / 6 (eth5) | **2** |
+| Default port bitmap | 0x62 (ports 1, 5, 6) | **0x06 (ports 1, 2)** |
+| Bitmap after exclusion | 0x42 / 0x22 | **0x02** |
+| NSS dataplane ports | dp1–dp6 | **dp1, dp2 only** |
+| SFP PHY chip | — | RTL8261 (causes aggressive re-init loop) |
+
+### Why SSDK_PORT_ID is 2, not 5
+
+The DR7 has only two NSS dataplane ports (dp1, dp2), compared to six on the UCG/UXG-Fiber.
+`eth4` maps to `dp1` (device-tree node `3a504000.dp1`), which is **SSDK port 2** on IPQ5322.
+This was confirmed via dmesg:
+
+```
+qca_mac_port_status_init: port 2 is RTL8261, force to enable flowctrl
+```
+
+Using the wrong port ID (e.g. 5 as in the original module) would remove a non-existent port
+from the bitmap and leave the actual SFP port unprotected — the MAC sync loop would continue
+resetting it every ~5 seconds.
+
+### Why the bitmap is 0x06
+
+The MAC sync loop on the DR7 only manages Port 1 and Port 2 (bitmap `0x06`). After excluding
+Port 2 (eth4/SFP), the remaining bitmap is `0x02` — the loop continues managing Port 1 (the
+internal switch / LAN ports) but no longer touches the SFP port.
+
+---
+
+## What the module does
+
+Same sequence as the original UCG-Fiber module, adapted for DR7 port topology:
+
+1. Reads the current port bitmap via `qca_ssdk_port_bmp_get()` (expected: `0x06`)
+2. Stops the MAC sync polling loop briefly to prevent races
+3. Removes Port 2 from the bitmap (`0x06 → 0x02`) via `qca_ssdk_port_bmp_set()`
+4. Calls `adpt_hppe_uniphy_mode_set(0, 1, 0x0c)` to set uniphy1 to SGMII+ mode:
+   - Sets SerDes register 0x07A10218 from `0x30` (SGMII 1G) to `0x50` (SGMII+)
+   - Performs PLL reset/relock (~200ms)
+   - Sets TX/RX clocks to 312.5 MHz
+5. Updates SSDK bookkeeping via `_adpt_hppe_port_interface_mode_set()` and `ssdk_dt_global_set_mac_mode()`
+6. Waits 1 second for link stabilization, then restarts the polling loop (Port 2 excluded)
+7. Writes 2500 to the SSDK SFP PHY speed cache, fires `ssdk_port_link_notify` and
+   `ubnt_send_phy_event`, triggers RTM_NEWLINK so ethtool/sysfs/UDAPI report 2500Mb/s
+8. On `rmmod`: restores speed cache, reverts uniphy1 to SGMII 1G, restores bitmap, restarts loop
+
+---
+
+## Verification (hardware confirmed)
+
+The following was verified on a DR7 running UniFi OS with kernel 5.4.213-ui-ipq5322-wireless:
+
+```bash
+# All three should show 2.5G after module load:
+cat /sys/kernel/debug/clk/uniphy1_gcc_tx_clk/clk_rate   # 312500000
+busybox devmem 0x07A10218 32                             # 0x00000050
+ethtool eth4 | grep Speed                               # Speed: 2500Mb/s
+
+# Internet connectivity confirmed working after module load:
+ping -c 3 8.8.8.8                                       # 0% packet loss
+
+# rmmod reverts correctly:
+# busybox devmem 0x07A10218 32                          # 0x00000030 (back to SGMII 1G)
+```
+
+dmesg output after successful load:
+```
+force_sgmiiplus: resolved all symbols via kallsyms
+force_sgmiiplus: current port bitmap: 0x6, will set: 0x2
+force_sgmiiplus: port bitmap 0x6 -> 0x2 (port 2 excluded)
+force_sgmiiplus: uniphy1 set to SGMII+ 2.5G (ret=0)
+force_sgmiiplus: loop restarted (port 2 excluded from bitmap)
+force_sgmiiplus: priv_data base addr: 0xffffff80bb220000
+force_sgmiiplus: speed cache: 1000 -> 2500, duplex cache: 1 -> 1
+force_sgmiiplus: ssdk_port_link_notify fired
+force_sgmiiplus: ubnt_send_phy_event fired
+force_sgmiiplus: speed reporting update triggered
+```
+
+> **Note:** Full end-to-end GPON throughput testing (2.5G downstream via ONT SFP) has not yet
+> been performed — the fiber connection is not yet active. Hardware-level verification (clock
+> rate, SerDes register, ethtool speed, internet connectivity) all pass. GPON test expected
+> within ~2 weeks; this note will be updated with results.
+
+---
+
+## Symbol resolution
+
+All symbols are resolved the same way as the original module via `kallsyms_lookup_name()` at
+load time. Confirmed addresses on this firmware version:
+
+| Symbol | Address |
+|---|---|
+| `adpt_hppe_uniphy_mode_set` | `ffffffc008a1dac8` |
+| `_adpt_hppe_port_interface_mode_set` | `ffffffc008a088b8` |
+| `ssdk_dt_global_set_mac_mode` | `ffffffc008ac63bc` |
+| `qca_ssdk_port_bmp_get` | `ffffffc008a5c150` |
+| `qca_ssdk_port_bmp_set` | `ffffffc008a5c130` |
+| `ssdk_phy_priv_data_get` | `ffffffc008acacf0` |
+| `ssdk_port_link_notify` | `ffffffc008a965a4` |
+| `ubnt_send_phy_event` | `ffffffc008a09478` |
+
+Addresses will differ across firmware versions — the module resolves them at runtime so no
+recompilation is needed after firmware updates. After any update, verify with:
+
+```bash
+dmesg | grep force_sgmiiplus
+# "resolved all symbols via kallsyms" = good
+# "kallsyms lookup failed" = module refused to load, check dmesg for which symbol is missing
+```
+
+---
+
+## Pre-check
+
+```bash
+# 1. Confirm kernel version
+uname -r
+# Expected: 5.4.213-ui-ipq5322-wireless
+
+# 2. Confirm qca-ssdk is loaded
+lsmod | grep qca_ssdk
+
+# 3. Check current state
+ip link show eth4
+cat /sys/kernel/debug/clk/uniphy1_gcc_tx_clk/clk_rate   # Expected: 125000000
+busybox devmem 0x07A10218 32                             # Expected: 0x00000030
+
+# 4. Confirm all symbols exist
+grep -E 'adpt_hppe_uniphy_mode_set|_adpt_hppe_port_interface_mode_set|ssdk_dt_global_set_mac_mode|qca_ssdk_port_bmp|ssdk_phy_priv_data|ssdk_port_link_notify|ubnt_send_phy_event' /proc/kallsyms
+# All 8 symbols must appear
+```
+
+---
+
+## Deployment
+
+Requires `udm-boot` to be installed for the boot script to run automatically.
+
+### 1. Copy module to DR7
+
+```bash
+ssh root@<dr7-ip> "mkdir -p /data/sfp-sgmiiplus"
+scp modules/force-uniphy1-sgmiiplus-dr7/force_uniphy1_sgmiiplus_dr7.ko \
+    root@<dr7-ip>:/data/sfp-sgmiiplus/
+```
+
+### 2. Copy boot script
+
+```bash
+scp scripts/20-sfp-sgmiiplus-dr7.sh root@<dr7-ip>:/data/on_boot.d/20-sfp-sgmiiplus.sh
+ssh root@<dr7-ip> "chmod +x /data/on_boot.d/20-sfp-sgmiiplus.sh"
+```
+
+### 3. Test run
+
+```bash
+ssh root@<dr7-ip> insmod /data/sfp-sgmiiplus/force_uniphy1_sgmiiplus_dr7.ko
+ssh root@<dr7-ip> dmesg | grep force_sgmiiplus
+ssh root@<dr7-ip> cat /sys/kernel/debug/clk/uniphy1_gcc_tx_clk/clk_rate  # 312500000
+ssh root@<dr7-ip> busybox devmem 0x07A10218 32                            # 0x00000050
+ssh root@<dr7-ip> ethtool eth4 | grep Speed                              # 2500Mb/s
+```
+
+---
+
+## Cross-compiling
+
+The DR7 has no gcc and no kernel headers. Cross-compile on an x86 machine:
+
+### Requirements
+
+- `aarch64-linux-gnu-gcc` (Ubuntu: `sudo apt install gcc-aarch64-linux-gnu`)
+- Kernel source tree matching `5.4.213-ui-ipq5322-wireless`
+- `.config` extracted from the DR7: `ssh root@<dr7-ip> "zcat /proc/config.gz" > .config`
+
+### Build
+
+```bash
+# Prepare kernel source (once)
+cd /path/to/linux-5.4.213
+make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- olddefconfig
+make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- prepare
+make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- modules_prepare
+
+# Build module
+cd modules/force-uniphy1-sgmiiplus-dr7/
+make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- KDIR=/path/to/linux-5.4.213
+
+# Verify architecture
+file force_uniphy1_sgmiiplus_dr7.ko
+# Expected: ELF 64-bit LSB relocatable, ARM aarch64
+```
+
+---
+
+## Reverting
+
+```bash
+# Immediate revert
+rmmod force_uniphy1_sgmiiplus_dr7
+busybox devmem 0x07A10218 32   # Should show 0x00000030 (back to SGMII 1G)
+
+# Permanent - remove boot script then unload
+rm /data/on_boot.d/20-sfp-sgmiiplus.sh
+rmmod force_uniphy1_sgmiiplus_dr7
+
+# Optional cleanup
+rm -rf /data/sfp-sgmiiplus
+```

--- a/modules/force-uniphy1-sgmiiplus-dr7/Makefile
+++ b/modules/force-uniphy1-sgmiiplus-dr7/Makefile
@@ -1,0 +1,14 @@
+obj-m += force_uniphy1_sgmiiplus_dr7.o
+
+# Cross-compile on an ARM64 host:
+#   make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- KDIR=/path/to/kernel/source
+#
+# The kernel source must match: 5.4.213-ui-ipq5322-wireless
+# Extract config from router:
+#   ssh root@<router-ip> "zcat /proc/config.gz" > .config
+
+all:
+	$(MAKE) -C $(KDIR) M=$(PWD) modules
+
+clean:
+	$(MAKE) -C $(KDIR) M=$(PWD) clean

--- a/modules/force-uniphy1-sgmiiplus-dr7/force_uniphy1_sgmiiplus_dr7.c
+++ b/modules/force-uniphy1-sgmiiplus-dr7/force_uniphy1_sgmiiplus_dr7.c
@@ -1,0 +1,297 @@
+/*
+ * force_uniphy1_sgmiiplus_dr7.c - Force Dream Router 7 uniphy1 (eth4/SFP) to SGMII+ 2.5G
+ *
+ * Ported from the UCG-Fiber/UXG-Fiber (IPQ9574) version by Ozark Connect.
+ * Adapted for UniFi Dream Router 7 (IPQ5322, kernel 5.4.213-ui-ipq5322-wireless).
+ *
+ * Key differences from the original:
+ *   - Target interface: eth4 (not eth6)
+ *   - UNIPHY_INDEX: 1 (same)
+ *   - SSDK_PORT_ID: 5 (dp1 on IPQ5322 = SSDK port 5)
+ *   - Port bitmap on DR7: 0x06 (only Port 1+2 in MAC sync loop, Port 5/eth4 already excluded)
+ *     The bitmap exclusion is kept for safety in case of SSDK re-init.
+ *   - ORIG_PORT_IFACE_MODE / ORIG_MAC_MODE: read dynamically at load time
+ *     (values differ between IPQ9574 and IPQ5322 SSDK builds)
+ *
+ * BUILD (cross-compile on ARM64 host):
+ *   make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- KDIR=/path/to/kernel/source
+ *
+ * LOAD:    insmod force_uniphy1_sgmiiplus_dr7.ko
+ * UNLOAD:  rmmod force_uniphy1_sgmiiplus_dr7   (reverts to SGMII 1G)
+ *
+ * VERIFY:
+ *   cat /sys/kernel/debug/clk/uniphy1_gcc_tx_clk/clk_rate  -> 312500000
+ *   busybox devmem 0x07A10218 32                            -> 0x00000050
+ *   ethtool eth4 | grep Speed                              -> Speed: 2500Mb/s
+ *
+ * WARNING: SSDK_PORT_ID must be confirmed for your firmware version.
+ *          Load the module, check dmesg for "port bitmap" line, verify
+ *          clock rate is 312500000 and devmem shows 0x50 before use in
+ *          production.
+ */
+
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/kallsyms.h>
+#include <linux/delay.h>
+#include <linux/kmod.h>
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Ozark Connect (ported for DR7/IPQ5322)");
+MODULE_DESCRIPTION("Force Dream Router 7 uniphy1 (eth4/SFP) to SGMII+ 2.5G");
+
+/* Exported by qca-ssdk.ko */
+extern int ssdk_mac_sw_sync_work_stop(unsigned int dev_id);
+extern int ssdk_mac_sw_sync_work_start(unsigned int dev_id);
+
+/* Local symbols resolved via kallsyms */
+typedef int (*uniphy_mode_set_fn)(unsigned int dev_id, unsigned int uniphy_index, int mode);
+typedef int (*port_iface_mode_set_fn)(unsigned int dev_id, unsigned long port_id, int mode);
+typedef int (*dt_global_set_mac_mode_fn)(unsigned long dev_id, int uniphy_index, unsigned int mode);
+typedef unsigned int (*port_bmp_get_fn)(unsigned int dev_id);
+typedef void (*port_bmp_set_fn)(unsigned int dev_id, unsigned int bmp);
+typedef unsigned long (*priv_data_get_fn)(unsigned int dev_id);
+typedef void (*phy_event_fn)(unsigned char port);
+typedef void (*link_notify_fn)(unsigned char port, unsigned char link,
+			       unsigned char speed, unsigned char duplex);
+
+static uniphy_mode_set_fn uniphy_mode_set;
+static port_iface_mode_set_fn port_iface_mode_set;
+static dt_global_set_mac_mode_fn dt_global_set_mac_mode;
+static port_bmp_get_fn port_bmp_get;
+static port_bmp_set_fn port_bmp_set;
+
+/* SGMII+ mode code (same across IPQ9574 and IPQ5322) */
+#define SSDK_UNIPHY_SGMIIPLUS   0x0c
+/* SGMII 1G restore mode on unload */
+#define SSDK_UNIPHY_SGMII_CH0   0x0f
+
+/* DR7-specific port mapping */
+#define UNIPHY_INDEX   1   /* uniphy1 drives eth4/SFP on DR7 */
+#define SSDK_PORT_ID   2   /* SSDK internal port number for eth4 on DR7.
+                            * Confirmed via dmesg: "port 2 is RTL8261" (SFP PHY).
+                            * DR7 only has dp1+dp2 (not 6 ports like UCG/UXG). */
+#define DEV_ID         0
+
+/* SGMII+ interface mode value for _adpt_hppe_port_interface_mode_set */
+#define PORT_MODE_SGMIIPLUS 6
+
+/* Speed reporting */
+#define SPEED_2500            2500
+#define DUPLEX_FULL           1
+#define LINK_NOTIFY_SPEED_2500 3
+
+/* Offsets into ssdk_phy_priv_data for the SFP PHY speed/duplex cache.
+ * Same structure layout as IPQ9574 - verified via kallsyms offset 0x690 */
+#define SPEED_CACHE_BASE  0x690
+#define DUPLEX_CACHE_BASE 0x6d0
+#define PORT_STRIDE       4
+
+/* Saved state for cleanup on unload */
+static unsigned int orig_port_bmp;
+static unsigned long priv_addr;
+static unsigned int orig_speed;
+static unsigned int orig_duplex;
+static int orig_port_iface_mode = -1;  /* read dynamically, -1 = unknown */
+static int orig_mac_mode = -1;         /* read dynamically, -1 = unknown */
+
+static int __init force_sgmiiplus_init(void)
+{
+	int ret;
+	unsigned int bmp;
+
+	/* Resolve all local SSDK symbols via kallsyms.
+	 * These are 't' (local) symbols - not exported, must use kallsyms. */
+	uniphy_mode_set = (uniphy_mode_set_fn)kallsyms_lookup_name(
+		"adpt_hppe_uniphy_mode_set");
+	port_iface_mode_set = (port_iface_mode_set_fn)kallsyms_lookup_name(
+		"_adpt_hppe_port_interface_mode_set");
+	dt_global_set_mac_mode = (dt_global_set_mac_mode_fn)kallsyms_lookup_name(
+		"ssdk_dt_global_set_mac_mode");
+	port_bmp_get = (port_bmp_get_fn)kallsyms_lookup_name(
+		"qca_ssdk_port_bmp_get");
+	port_bmp_set = (port_bmp_set_fn)kallsyms_lookup_name(
+		"qca_ssdk_port_bmp_set");
+
+	if (!uniphy_mode_set || !port_iface_mode_set || !dt_global_set_mac_mode ||
+	    !port_bmp_get || !port_bmp_set) {
+		pr_err("force_sgmiiplus: kallsyms lookup failed - "
+		       "uniphy_mode_set=%p port_iface_mode_set=%p "
+		       "dt_global_set_mac_mode=%p port_bmp_get=%p port_bmp_set=%p\n",
+		       uniphy_mode_set, port_iface_mode_set, dt_global_set_mac_mode,
+		       port_bmp_get, port_bmp_set);
+		return -ENOENT;
+	}
+
+	pr_info("force_sgmiiplus: resolved all symbols via kallsyms\n");
+
+	/* Save current port bitmap and exclude our SFP port.
+	 * On DR7, MAC sync loop only manages Port 1+2 (bitmap 0x06).
+	 * Port 5 (eth4/SFP) is already excluded at boot, but we do this
+	 * anyway for safety and to match original module behavior. */
+	orig_port_bmp = port_bmp_get(DEV_ID);
+	bmp = orig_port_bmp & ~(1u << SSDK_PORT_ID);
+
+	pr_info("force_sgmiiplus: current port bitmap: 0x%x, will set: 0x%x\n",
+		orig_port_bmp, bmp);
+
+	/* Sanity check: expected bitmap on DR7 is 0x06 (bit1=Port1, bit2=Port2).
+	 * After we clear bit2 (Port2/eth4/SFP), result should be 0x04.
+	 * If orig_port_bmp is unexpected, warn but continue. */
+	if (orig_port_bmp != 0x06) {
+		pr_warn("force_sgmiiplus: unexpected port bitmap 0x%x (expected 0x06). "
+			"After exclusion: 0x%x. If networking breaks after load, "
+			"SSDK_PORT_ID=%d may be wrong - check 'dmesg | grep RTL8261'.\n",
+			orig_port_bmp, bmp, SSDK_PORT_ID);
+	}
+
+	ssdk_mac_sw_sync_work_stop(DEV_ID);
+
+	port_bmp_set(DEV_ID, bmp);
+	pr_info("force_sgmiiplus: port bitmap 0x%x -> 0x%x (port %d excluded)\n",
+		orig_port_bmp, bmp, SSDK_PORT_ID);
+
+	/* Set uniphy1 to SGMII+ 2.5G mode.
+	 * This switches SerDes register 0x218 from 0x30 (SGMII) to 0x50 (SGMII+),
+	 * performs PLL reset/relock (~200ms), and sets TX/RX clocks to 312.5 MHz. */
+	ret = uniphy_mode_set(DEV_ID, UNIPHY_INDEX, SSDK_UNIPHY_SGMIIPLUS);
+	if (ret != 0) {
+		pr_err("force_sgmiiplus: uniphy_mode_set failed: %d - reverting\n", ret);
+		port_bmp_set(DEV_ID, orig_port_bmp);
+		ssdk_mac_sw_sync_work_start(DEV_ID);
+		return ret;
+	}
+	pr_info("force_sgmiiplus: uniphy%d set to SGMII+ 2.5G (ret=%d)\n",
+		UNIPHY_INDEX, ret);
+
+	/* Update SSDK bookkeeping so any SSDK code path that checks port mode
+	 * sees a consistent SGMII+ state. We don't know the original values
+	 * on IPQ5322 so we save -1 (unknown) and skip restore if so. */
+	port_iface_mode_set(DEV_ID, SSDK_PORT_ID, PORT_MODE_SGMIIPLUS);
+	dt_global_set_mac_mode(DEV_ID, UNIPHY_INDEX, SSDK_UNIPHY_SGMIIPLUS);
+
+	/* Wait for link to stabilize after PLL relock */
+	msleep(1000);
+
+	/* Restart MAC sync loop - it now manages Ports 1+2 but skips Port 5 */
+	ssdk_mac_sw_sync_work_start(DEV_ID);
+	pr_info("force_sgmiiplus: loop restarted (port %d excluded from bitmap)\n",
+		SSDK_PORT_ID);
+
+	/* --- Speed reporting: make ethtool/sysfs/UDAPI show 2500Mb/s --- */
+	{
+		priv_data_get_fn get_priv;
+		phy_event_fn send_phy_event;
+		link_notify_fn notify;
+		unsigned int *sp, *dp;
+
+		get_priv = (priv_data_get_fn)
+			kallsyms_lookup_name("ssdk_phy_priv_data_get");
+		if (get_priv) {
+			priv_addr = get_priv(DEV_ID);
+			pr_info("force_sgmiiplus: priv_data base addr: 0x%lx\n",
+				priv_addr);
+		} else {
+			pr_warn("force_sgmiiplus: ssdk_phy_priv_data_get not found, "
+				"speed reporting will show 1000Mb/s\n");
+		}
+
+		if (priv_addr) {
+			sp = (unsigned int *)(priv_addr + SPEED_CACHE_BASE +
+					     (SSDK_PORT_ID - 1) * PORT_STRIDE);
+			dp = (unsigned int *)(priv_addr + DUPLEX_CACHE_BASE +
+					     (SSDK_PORT_ID - 1) * PORT_STRIDE);
+			orig_speed  = *sp;
+			orig_duplex = *dp;
+			*sp = SPEED_2500;
+			*dp = DUPLEX_FULL;
+			pr_info("force_sgmiiplus: speed cache: %u -> %u, "
+				"duplex cache: %u -> %u\n",
+				orig_speed, SPEED_2500, orig_duplex, DUPLEX_FULL);
+		}
+
+		notify = (link_notify_fn)
+			kallsyms_lookup_name("ssdk_port_link_notify");
+		if (notify) {
+			notify(SSDK_PORT_ID, 1, LINK_NOTIFY_SPEED_2500, 1);
+			pr_info("force_sgmiiplus: ssdk_port_link_notify fired\n");
+		}
+
+		send_phy_event = (phy_event_fn)
+			kallsyms_lookup_name("ubnt_send_phy_event");
+		if (send_phy_event) {
+			send_phy_event(SSDK_PORT_ID);
+			pr_info("force_sgmiiplus: ubnt_send_phy_event fired\n");
+		}
+
+		/* Trigger RTM_NEWLINK so UDAPI re-reads ethtool speed.
+		 * 2s delay gives PHY state machine time to copy cache -> phydev->speed.
+		 * UMH_NO_WAIT: module init returns immediately. */
+		{
+			static char *argv[] = {
+				"/bin/sh", "-c",
+				"sleep 2 && ip link set eth4 alias x && ip link set eth4 alias ''",
+				NULL
+			};
+			static char *envp[] = { "PATH=/sbin:/bin", NULL };
+
+			call_usermodehelper(argv[0], argv, envp, UMH_NO_WAIT);
+		}
+
+		pr_info("force_sgmiiplus: speed reporting update triggered\n");
+	}
+
+	pr_info("force_sgmiiplus: done - verify with:\n"
+		"  cat /sys/kernel/debug/clk/uniphy1_gcc_tx_clk/clk_rate  (expect 312500000)\n"
+		"  busybox devmem 0x07A10218 32                            (expect 0x00000050)\n"
+		"  ethtool eth4 | grep Speed                              (expect 2500Mb/s)\n");
+
+	return 0;
+}
+
+static void __exit force_sgmiiplus_exit(void)
+{
+	if (!uniphy_mode_set)
+		return;
+
+	pr_info("force_sgmiiplus: unloading, reverting to SGMII 1G\n");
+
+	/* Restore speed cache */
+	if (priv_addr) {
+		unsigned int *sp = (unsigned int *)(priv_addr + SPEED_CACHE_BASE +
+						   (SSDK_PORT_ID - 1) * PORT_STRIDE);
+		unsigned int *dp = (unsigned int *)(priv_addr + DUPLEX_CACHE_BASE +
+						   (SSDK_PORT_ID - 1) * PORT_STRIDE);
+		*sp = orig_speed;
+		*dp = orig_duplex;
+		pr_info("force_sgmiiplus: speed cache restored to %u\n", orig_speed);
+	}
+
+	ssdk_mac_sw_sync_work_stop(DEV_ID);
+
+	/* Revert uniphy1 to SGMII 1G */
+	uniphy_mode_set(DEV_ID, UNIPHY_INDEX, SSDK_UNIPHY_SGMII_CH0);
+	pr_info("force_sgmiiplus: uniphy%d reverted to SGMII 1G\n", UNIPHY_INDEX);
+
+	/* Revert SSDK bookkeeping.
+	 * We don't have the exact original values for IPQ5322, so we skip
+	 * port_iface_mode_set/dt_global_set_mac_mode on revert.
+	 * The uniphy_mode_set() call above already resets the hardware SerDes.
+	 * If SSDK bookkeeping mismatch causes issues after rmmod, reboot to clean state. */
+	if (orig_port_iface_mode >= 0 && port_iface_mode_set)
+		port_iface_mode_set(DEV_ID, SSDK_PORT_ID, orig_port_iface_mode);
+
+	if (orig_mac_mode >= 0)
+		dt_global_set_mac_mode(DEV_ID, UNIPHY_INDEX, orig_mac_mode);
+
+	/* Restore full port bitmap */
+	if (port_bmp_set)
+		port_bmp_set(DEV_ID, orig_port_bmp);
+
+	ssdk_mac_sw_sync_work_start(DEV_ID);
+	pr_info("force_sgmiiplus: reverted, loop restarted with bitmap 0x%x\n",
+		orig_port_bmp);
+}
+
+module_init(force_sgmiiplus_init);
+module_exit(force_sgmiiplus_exit);

--- a/scripts/20-sfp-sgmiiplus-dr7.sh
+++ b/scripts/20-sfp-sgmiiplus-dr7.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+SCRIPT_NAME="sfp-sgmiiplus"
+LOG_FILE="/var/log/${SCRIPT_NAME}.log"
+MODULE_DIR="/data/sfp-sgmiiplus"
+MODULE_NAME="force_uniphy1_sgmiiplus_dr7"
+MODULE_FILE="${MODULE_DIR}/${MODULE_NAME}.ko"
+CLOCK_PATH="/sys/kernel/debug/clk/uniphy1_gcc_tx_clk/clk_rate"
+IFACE="eth4"
+CARRIER_TIMEOUT=90
+
+log() {
+    echo "$(date '+%Y-%m-%d %H:%M:%S') - $1" >> "${LOG_FILE}"
+}
+
+if [ "$1" != "--bg" ]; then
+    nohup "$0" --bg >/dev/null 2>&1 &
+    exit 0
+fi
+
+if [ ! -f "${MODULE_FILE}" ]; then
+    log "ERROR: ${MODULE_FILE} not found"
+    exit 1
+fi
+if lsmod | grep -q "${MODULE_NAME}"; then
+    log "Module already loaded"
+    exit 0
+fi
+if ! lsmod | grep -q "qca_ssdk"; then
+    log "ERROR: qca-ssdk not loaded"
+    exit 1
+fi
+
+elapsed=0
+while [ $elapsed -lt $CARRIER_TIMEOUT ]; do
+    carrier=$(cat /sys/class/net/${IFACE}/carrier 2>/dev/null)
+    if [ "$carrier" = "1" ]; then
+        log "${IFACE} has carrier after ${elapsed}s"
+        break
+    fi
+    sleep 2
+    elapsed=$((elapsed + 2))
+done
+
+if [ "$carrier" != "1" ]; then
+    log "${IFACE} no carrier after ${CARRIER_TIMEOUT}s - loading anyway"
+fi
+
+BEFORE_CLOCK=$(cat "${CLOCK_PATH}" 2>/dev/null)
+log "Clock before: ${BEFORE_CLOCK} Hz"
+
+insmod "${MODULE_FILE}" 2>> "${LOG_FILE}"
+RET=$?
+if [ ${RET} -ne 0 ]; then
+    log "ERROR: insmod failed (${RET})"
+    exit 1
+fi
+
+sleep 1
+AFTER_CLOCK=$(cat "${CLOCK_PATH}" 2>/dev/null)
+log "Clock after: ${AFTER_CLOCK} Hz"
+
+if [ "${AFTER_CLOCK}" = "312500000" ]; then
+    log "Verified: 312.5 MHz (SGMII+ 2.5G) - OK"
+else
+    log "WARNING: Expected 312500000, got ${AFTER_CLOCK}"
+fi
+
+log "Done"


### PR DESCRIPTION
Adds SGMII+ 2.5G support for the UniFi Dream Router 7 (IPQ5322)
Port of force_uniphy1_sgmiiplus for the DR7, which uses the IPQ5322 SoC instead of the IPQ9574 on UCG/UXG-Fiber.
Key differences discovered during porting:

SSDK_PORT_ID is 2 (not 5) — DR7 only has dp1/dp2, eth4 = SSDK port 2
Default port bitmap is 0x06 (ports 1+2 only, not 0x62)
RTL8261 PHY in the SFP port causes aggressive uniphy re-init every ~5s without bitmap exclusion
Interface is eth4 (not eth6/eth5)

Verified on: 5.4.213-ui-ipq5322-wireless

Clock: 312.5 MHz ✅
SerDes register 0x07A10218: 0x00000050 ✅
ethtool: 2500Mb/s ✅
Internet connectivity: OK ✅
rmmod revert: OK ✅

Pending: Full GPON throughput test (fiber connection not yet active, ~2 weeks).

Note: I figured out the IPQ5322-specific port topology and got this working with the help of Claude (Anthropic). The key insights — SSDK_PORT_ID=2, the RTL8261 re-init loop, and the bitmap difference — were all identified by systematically reading dmesg, kallsyms, and the clock/SerDes registers before touching anything. Previous attempts with other AI assistants broke networking due to wrong port constants.