### PR TITLE
Recover UniPHY1 SGMII+ mode after SFP resets

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ SFP+ port status check - reads the uniphy SerDes registers and clock rates for b
 ssh root@<gateway-ip> 'sh -s' < scripts/diagnostics/sfp-link-check.sh
 ```
 
-Reports the actual physical-layer speed by reading uniphy SerDes registers directly. Useful for confirming the SGMII+ module is working. With module v4+, `ethtool` and the UniFi UI also report 2500 Mbps correctly.
+Reports the actual physical-layer speed by reading uniphy SerDes registers directly. Useful for confirming the SGMII+ module is working; `ethtool` and the UniFi UI should also report 2500 Mbps correctly.
 
 ## Reverting
 

--- a/docs/sfp-sgmiiplus.md
+++ b/docs/sfp-sgmiiplus.md
@@ -19,17 +19,25 @@ The SGMII+ mode set requires kernel-level operations that can't be done from use
 
 ## What the modules do
 
-Both modules (uniphy1 for eth6, uniphy2 for eth5) follow the same sequence:
+Both modules save the SSDK state, exclude their target port from the MAC-sync
+bitmap, program SGMII+ mode, update the speed cache, and restore the saved
+state on unload.
 
-1. Saves the current port bitmap via `qca_ssdk_port_bmp_get()`, then stops the MAC sync polling loop briefly to prevent races during the mode change
-2. Excludes the target port from the polling loop's port bitmap via `qca_ssdk_port_bmp_set()` - the loop will skip the port entirely, preventing it from forcing the MAC to 1G
-3. Sets the target uniphy to SGMII+ mode by calling `adpt_hppe_uniphy_mode_set(0, uniphy_index, 0x0c)`, which sets uniphy register 0x218 to 0x50 (SGMII+ SerDes mode, vs 0x30 for SGMII), performs the PLL reset/relock sequence (reg 0x780: 0x2bf to 0x2ff, ~200ms), updates mode control register 0x46c with SGMII+ flags, runs software reset and calibration, and sets the TX/RX clocks to 312.5 MHz
-4. Updates SSDK bookkeeping: sets the per-port interface mode via `_adpt_hppe_port_interface_mode_set()` and the per-uniphy global mac_mode via `ssdk_dt_global_set_mac_mode()`
-5. Waits 1 second for the link to stabilize after the mode change, then restarts the polling loop - the loop now manages all other ports but skips the target port
-6. Writes 2500 to the SSDK SFP PHY speed cache (`ssdk_phy_priv_data` at offset 0x690), fires `ssdk_port_link_notify` and `ubnt_send_phy_event`, then triggers an async `RTM_NEWLINK` (transient interface alias set/clear) so `ubios-udapi-server` re-reads ethtool. This makes ethtool, sysfs, UDAPI, and UniFi Network all report 2.5G
-7. On unload (`rmmod`), restores the speed cache to its original value and reverts all state (uniphy mode, port interface mode, mac_mode, port bitmap), then restarts the polling loop with the full port set
+The UniPHY1/eth6 module additionally makes the complete host-side transition:
 
-The mode set causes the target interface to flap briefly (~300ms) while the PLL relocks.
+1. It uses `adpt_hppe_port_interface_mode_set()` to force SGMII+, so an SFP
+   EEPROM event cannot silently restore the port to 1000BASE-X.
+2. It disables the MAC path, programs the UniPHY and APPE XGMAC path, then
+   brings the path back at 2500/full.
+3. A one-second monitor checks the physical mode, forced-interface flag,
+   XGMAC selection, global mode, and bitmap. On drift it quiesces the path,
+   repeats the vendor transition, and resynchronizes host link state from PCS.
+4. On unload it stops the monitor before restoring the original interface,
+   mode, cache, and bitmap state.
+
+The UniPHY2/eth5 module remains a one-shot transition. Loading or recovering
+the UniPHY1 module briefly flaps eth6 while the SerDes and MAC path are
+reconfigured.
 
 ### Port-to-module mapping
 
@@ -44,7 +52,7 @@ Loading both modules simultaneously is **not currently supported**. Each module 
 
 ### Port bitmap exclusion
 
-Each module removes its target port from the SSDK's polling loop port bitmap. This is a runtime-only change to a value in kernel memory - it persists as long as the module is loaded and is restored on unload. The polling loop continues managing all other ports for link state, speed/duplex sync, and flow control.
+Each module removes its target port from the SSDK's polling loop port bitmap. This is a runtime-only change to a value in kernel memory - it persists as long as the module is loaded and is restored on unload. The polling loop continues managing all other ports for link state, speed/duplex sync, and flow control. The UniPHY1 monitor also re-clears the eth6 bit if another SSDK path restores it.
 
 The bitmap exclusion is necessary because the loop reads link speed from a PPE hardware register that always reports 1000M for SGMII+ links (the SGMII in-band protocol has no 2.5G speed code). If the loop managed the port, it would force the MAC to 1G on every link-up event, creating a MAC/SerDes speed mismatch that kills the data path.
 
@@ -52,24 +60,25 @@ Default port bitmap is `0x62` (ports 1, 5, 6). The uniphy1 module clears bit 5 (
 
 ### SSDK bookkeeping
 
-Each module also writes to two SSDK internal data structures (per-port interface mode and per-uniphy mac_mode). These are the same structures the SSDK itself writes during normal port initialization - the module sets them to SGMII+ values so any SSDK code path that checks the port mode sees a consistent state.
-
-### Version history
-
-v1 stopped the MAC sync polling loop entirely. This caused forwarding drops on eth5 and flow control loss during UniFi Network config pushes (IDS/IPS toggle, etc.), because the loop manages link state for all ports. v2 updated bookkeeping and restarted the loop, but the loop's link-up speed sync (reading 1000M from PPE) broke the 2.5G data path on cold starts (SFP reboot, gateway reboot, DSMP restart). v3 excludes port 5/eth6 from the bitmap, keeping the loop running for all other ports while preventing it from touching our SGMII+ port. v4 (current) adds speed reporting: writes 2500 to the SSDK SFP PHY speed cache so ethtool/sysfs/UDAPI/UniFi Network all report 2.5G instead of the misleading 1000M. If you are running v1, v2, or v3, upgrade.
+Each module writes SSDK interface and global-mode state so readers see a
+consistent SGMII+ configuration. UniPHY1 uses the public interface-mode setter
+to retain the forced mode, programs the APPE MAC mux to XGMAC, and keeps the
+link, speed, and duplex caches synchronized from PCS rather than GPON RX_LOS.
 
 ### Symbol resolution
 
-The module resolves three symbols from `qca-ssdk.ko` at load time. Their addresses change across UniFi OS versions even though the kernel stays the same - Ubiquiti ships a different `qca-ssdk.ko` build with each release:
+The modules resolve private symbols from `qca-ssdk.ko` at load time. Their addresses can change across UniFi OS builds:
 
 | Symbol | Type | Resolution | Purpose |
 |---|---|---|---|
-| `adpt_hppe_uniphy_mode_set` | local (t) | kallsyms | Uniphy SerDes mode set |
-| `_adpt_hppe_port_interface_mode_set` | local (t) | kallsyms | Per-port interface mode bookkeeping |
-| `ssdk_dt_global_set_mac_mode` | local (t) | kallsyms | Per-uniphy global mac_mode bookkeeping |
+| `adpt_hppe_uniphy_mode_set` | local (t) | kallsyms | UniPHY SerDes mode set |
+| `adpt_hppe_port_interface_mode_set`, `_adpt_hppe_port_interface_mode_set`, `adpt_hppe_port_interface_mode_get` | local (t) | kallsyms | Forced interface mode and saved-mode restoration |
+| `ssdk_dt_global_get_mac_mode`, `ssdk_dt_global_set_mac_mode` | local (t) | kallsyms | Per-UniPHY global-mode state |
 | `qca_ssdk_port_bmp_get` | local (t) | kallsyms | Read polling loop port bitmap |
 | `qca_ssdk_port_bmp_set` | local (t) | kallsyms | Write polling loop port bitmap |
-| `ssdk_phy_priv_data_get` | local (t) | kallsyms | SSDK private data (SFP PHY speed cache) |
+| `adpt_hppe_port_mux_mac_type_set`, `qca_hppe_port_mac_type_get` | local (t) | kallsyms | APPE GMAC/XGMAC transition and verification |
+| `hppe_uniphy_channel0_input_output_6_get`, `hppe_uniphy_phy_mode_ctrl_get` | local (t) | kallsyms | PCS link and physical-mode reads |
+| `ssdk_phy_priv_data_get` | local (t) | kallsyms | SSDK link, speed, and duplex caches |
 | `ssdk_port_link_notify` | local (t) | kallsyms | Link state notifier chain |
 | `ubnt_send_phy_event` | local (t) | kallsyms | UniFi PHY event netlink notification |
 
@@ -92,7 +101,7 @@ After loading, confirm the symbols resolved:
 
 ```bash
 dmesg | grep force_sgmiiplus
-# "resolved all symbols via kallsyms" = good
+# "resolved symbols" = dependencies resolved
 # "lookup failed" = module refused to load
 ```
 
@@ -233,42 +242,23 @@ cat /var/log/sfp-sgmiiplus-eth5.log   # eth5
 dmesg | grep force_sgmiiplus
 ```
 
-### Boot-time retry
+### UniPHY1 boot and recovery
 
-The boot-time mode set does not always commit. `insmod` can succeed and the module
-can log `uniphy1 set to SGMII+ 2.5G` while the uniphy clock stays at 125 MHz and the
-port sits at NO-CARRIER against an SFP that has already switched to 2.5G. A set that
-*does* commit can still be reverted up to ~35s later when it happens early in boot.
-Which boots are affected is timing-dependent, so the same firmware and SFP can boot
-cleanly and fail on the next try.
+The eth6 loader waits for `qca_ssdk`, then performs exactly one `insmod`.
+Recovery stays in the module for its full lifetime: it can correct a later SFP
+event that rewrites physical or MAC state without repeatedly unloading a live
+WAN module. The loader requires the 312.5 MHz clock to remain stable for 15
+consecutive seconds within a 60-second window. If that check fails, it leaves
+the module loaded so the monitor can continue recovery.
 
-The scripts handle this themselves. After each `insmod` they require the clock to read
-312500000 Hz *and hold it for 45s* — a single read one second after load only proves a
-momentary state. On a mismatch the script `rmmod`s to restore stock SGMII 1G, waits up
-to 30s for the stock 1G link to recover, backs off, and retries; 5 attempts total.
+Expected recovery evidence after a late mode reset includes:
 
-Success is judged on the clock only, never on carrier, so SFPs that are hard-locked at
-2.5G and cannot establish a 1G link still work.
-
-If all five attempts fail, the module is removed and the port is left in stock SGMII 1G
-state — the WAN keeps working at 1G instead of staying dead — and the script logs an
-ERROR and exits non-zero:
-
+```text
+mode drift detected: ...; reasserting SGMII+
+vendor mode transition complete: mode=0xc mac_type=2 speed=2500
+SGMII+ mode restored after drift
+PCS status ..., host link ...
 ```
-WARNING: Attempt 1 expected 312500000 Hz, got 125000000 Hz
-Removing force_uniphy1_sgmiiplus to restore stock SGMII 1G before retry
-eth6 stock 1G carrier recovered after 2s
-Retrying after 5s backoff
-Loading force_uniphy1_sgmiiplus (attempt 2/5)...
-Clock rate after attempt 2: 312500000 Hz
-Clock reached 312500000 Hz; verifying it holds for 45s
-Verified: uniphy1 running at 312.5 MHz (SGMII+ 2.5G) and held for 45s
-```
-
-The retry is deliberately bounded: if something on the host actively re-asserts 1G, an
-unbounded loop would flap the WAN forever. Worst case the loop runs ~7 minutes after the
-initial carrier wait, bouncing the port up to five times. It runs in the background, so
-`on_boot.d` is never blocked.
 
 ## Reverting
 

--- a/modules/force-uniphy1-sgmiiplus/force_uniphy1_sgmiiplus.c
+++ b/modules/force-uniphy1-sgmiiplus/force_uniphy1_sgmiiplus.c
@@ -18,20 +18,23 @@
  * VERIFY:  cat /sys/kernel/debug/clk/uniphy1_gcc_tx_clk/clk_rate
  *          (should show 312500000 after load, 125000000 after unload)
  *
- * Also writes 2500 to the SSDK SFP PHY speed cache so that ethtool,
- * sysfs, and UniFi Network all report 2.5G. The "QCA SFP" fake PHY
- * driver's sfp_read_status() copies speed from this cache into
- * phydev->speed. After writing, fires ssdk_port_link_notify and
- * ubnt_send_phy_event, then triggers an RTM_NEWLINK via a transient
- * interface alias so UDAPI re-reads ethtool.
+ * Also maintains the SSDK fake-PHY link, speed, and duplex caches. Mode
+ * changes follow the vendor sequence: update the global mode, select the
+ * UniPHY1 clock source, program the SerDes, then configure the port-5 MAC
+ * type, mux, reset, flow control, and speed clock. A small kthread reads
+ * both the physical UniPHY mode and its PCS link bit. If a later QCA SFP
+ * event changes UniPHY1 back to native SGMII, the thread atomically
+ * reasserts the complete SGMII+ path before resynchronizing the MAC.
+ * GPON RX_LOS remains deliberately ignored because it describes the PON
+ * optical state, not the Ethernet host-side link.
  */
 
 #include <linux/module.h>
 #include <linux/kernel.h>
 #include <linux/kallsyms.h>
 #include <linux/delay.h>
-#include <linux/kmod.h>
-
+#include <linux/err.h>
+#include <linux/kthread.h>
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("Ozark Connect");
 MODULE_DESCRIPTION("Force UCG-Fiber / UXG-Fiber uniphy1 to SGMII+ 2.5G");
@@ -42,177 +45,666 @@ extern int ssdk_mac_sw_sync_work_start(unsigned int dev_id);
 
 /* Local symbols resolved via kallsyms */
 typedef int (*uniphy_mode_set_fn)(unsigned int dev_id, unsigned int uniphy_index, int mode);
-typedef int (*port_iface_mode_set_fn)(unsigned int dev_id, unsigned long port_id, int mode);
-typedef int (*dt_global_set_mac_mode_fn)(unsigned long dev_id, int uniphy_index, unsigned int mode);
+typedef int (*port_iface_mode_set_fn)(unsigned int dev_id, unsigned int port_id, int mode);
+typedef int (*port_iface_mode_get_fn)(unsigned int dev_id, unsigned int port_id, int *mode);
+typedef unsigned int (*dt_global_get_mac_mode_fn)(unsigned int dev_id,
+						  unsigned int uniphy_index);
+typedef int (*dt_global_set_mac_mode_fn)(unsigned int dev_id,
+					 unsigned int uniphy_index,
+					 unsigned int mode);
 typedef unsigned int (*port_bmp_get_fn)(unsigned int dev_id);
 typedef void (*port_bmp_set_fn)(unsigned int dev_id, unsigned int bmp);
+typedef int (*port_feature_get_fn)(unsigned int dev_id, unsigned int port_id,
+				   unsigned int feature);
 typedef unsigned long (*priv_data_get_fn)(unsigned int dev_id);
 typedef void (*phy_event_fn)(unsigned char port);
 typedef void (*link_notify_fn)(unsigned char port, unsigned char link,
 			       unsigned char speed, unsigned char duplex);
 
+typedef int (*uniphy_status_get_fn)(unsigned int dev_id,
+				    unsigned int uniphy_index,
+				    unsigned int *status);
+typedef int (*uniphy_phy_mode_get_fn)(unsigned int dev_id,
+				     unsigned int uniphy_index,
+				     unsigned int *mode);
+typedef int (*port_control_set_fn)(unsigned int dev_id,
+				   unsigned int port_id,
+				   int value);
+typedef int (*port_mux_mac_type_set_fn)(unsigned int dev_id,
+					unsigned int port_id,
+					unsigned int mode0,
+					unsigned int mode1,
+					unsigned int mode2);
+typedef unsigned int (*port_mac_type_get_fn)(unsigned int dev_id,
+					     unsigned int port_id);
+typedef void (*port5_clock_source_set_fn)(void);
+typedef void (*port_speed_clock_set_fn)(unsigned int dev_id,
+					unsigned int port_id,
+					int speed);
 static uniphy_mode_set_fn uniphy_mode_set;
-static port_iface_mode_set_fn port_iface_mode_set;
+static port_iface_mode_set_fn port_iface_mode_force;
+static port_iface_mode_set_fn port_iface_mode_set_raw;
+static port_iface_mode_get_fn port_iface_mode_get;
+static dt_global_get_mac_mode_fn dt_global_get_mac_mode;
 static dt_global_set_mac_mode_fn dt_global_set_mac_mode;
 static port_bmp_get_fn port_bmp_get;
 static port_bmp_set_fn port_bmp_set;
+static port_feature_get_fn port_feature_get;
+static uniphy_status_get_fn uniphy_status_get;
+static uniphy_phy_mode_get_fn uniphy_phy_mode_get;
+static priv_data_get_fn priv_data_get;
+static phy_event_fn send_phy_event;
+static link_notify_fn link_notify;
+static port_control_set_fn port_txmac_set;
+static port_control_set_fn port_rxmac_set;
+static port_control_set_fn port_bridge_txmac_set;
+static port_control_set_fn port_mac_speed_set;
+static port_control_set_fn port_mac_duplex_set;
+static port_mux_mac_type_set_fn port_mux_mac_type_set;
+static port_mac_type_get_fn port_mac_type_get;
+static port5_clock_source_set_fn port5_clock_source_set;
+static port_speed_clock_set_fn port_speed_clock_set;
 
 #define SSDK_UNIPHY_SGMIIPLUS 0x0c
-#define SSDK_UNIPHY_SGMII_CH0 0x0f
 #define UNIPHY_INDEX 1
 #define SSDK_PORT_ID 5
 #define DEV_ID 0
 #define PORT_MODE_SGMIIPLUS 6
-#define ORIG_PORT_IFACE_MODE 0x0e
-#define ORIG_MAC_MODE 0x14
+#define PORT_INTERFACE_MODE_AUTO 17
+#define PHY_F_FORCE_INTERFACE_MODE (1u << 9)
 
 #define SPEED_2500   2500
-#define DUPLEX_FULL  1
+#define SSDK_DUPLEX_FULL 1
 #define LINK_NOTIFY_SPEED_2500 3
+#define PORT_XGMAC_TYPE 2
 
+#define LINK_CACHE_BASE   0x650
 #define SPEED_CACHE_BASE  0x690
 #define DUPLEX_CACHE_BASE 0x6d0
 #define PORT_STRIDE       4
+#define UNIPHY_PCS_LINK_BIT (1u << 7)
+#define LINK_MONITOR_INTERVAL_MS 1000
+#define UNIPHY_PHY_MODE_MASK 0x70
+#define UNIPHY_PHY_MODE_SGMIIPLUS 0x50
+
 
 static unsigned int orig_port_bmp;
+static int orig_port_iface_mode;
+static unsigned int orig_mac_mode;
+static bool orig_force_interface_mode;
+static unsigned int orig_port_mac_type;
 static unsigned long priv_addr;
+static unsigned int *link_cache;
+static unsigned int *speed_cache;
+static unsigned int *duplex_cache;
+static unsigned int orig_link;
 static unsigned int orig_speed;
 static unsigned int orig_duplex;
+static struct task_struct *link_monitor_task;
+static bool recovery_sync_worker_stopped;
+
+static void force_sgmiiplus_notify_host_link(unsigned int link)
+{
+	if (link_notify)
+		link_notify(SSDK_PORT_ID, link,
+			    link ? LINK_NOTIFY_SPEED_2500 : 0,
+			    link ? SSDK_DUPLEX_FULL : 0);
+
+	if (send_phy_event)
+		send_phy_event(SSDK_PORT_ID);
+}
+
+static int force_sgmiiplus_set_data_path(unsigned int link)
+{
+	int ret;
+
+	if (!link) {
+		ret = port_bridge_txmac_set(DEV_ID, SSDK_PORT_ID, 0);
+		if (ret) {
+			pr_err("force_sgmiiplus: failed to disable bridge TX MAC: %d\n",
+			       ret);
+			return ret;
+		}
+
+		msleep(10);
+		ret = port_txmac_set(DEV_ID, SSDK_PORT_ID, 0);
+		if (ret) {
+			pr_err("force_sgmiiplus: failed to disable TX MAC: %d\n",
+			       ret);
+			return ret;
+		}
+
+		ret = port_rxmac_set(DEV_ID, SSDK_PORT_ID, 0);
+		if (ret) {
+			pr_err("force_sgmiiplus: failed to disable RX MAC: %d\n",
+			       ret);
+			return ret;
+		}
+
+		pr_info("force_sgmiiplus: MAC data path disabled\n");
+		return 0;
+	}
+
+	ret = port_txmac_set(DEV_ID, SSDK_PORT_ID, 0);
+	if (ret) {
+		pr_err("force_sgmiiplus: failed to pause TX MAC: %d\n", ret);
+		return ret;
+	}
+
+	ret = port_mac_speed_set(DEV_ID, SSDK_PORT_ID, SPEED_2500);
+	if (ret) {
+		pr_err("force_sgmiiplus: failed to set MAC speed: %d\n", ret);
+		return ret;
+	}
+
+	ret = port_mac_duplex_set(DEV_ID, SSDK_PORT_ID, SSDK_DUPLEX_FULL);
+	if (ret) {
+		pr_err("force_sgmiiplus: failed to set MAC duplex: %d\n", ret);
+		return ret;
+	}
+
+	ret = port_txmac_set(DEV_ID, SSDK_PORT_ID, 1);
+	if (ret) {
+		pr_err("force_sgmiiplus: failed to enable TX MAC: %d\n", ret);
+		return ret;
+	}
+
+	ret = port_rxmac_set(DEV_ID, SSDK_PORT_ID, 1);
+	if (ret) {
+		pr_err("force_sgmiiplus: failed to enable RX MAC: %d\n", ret);
+		return ret;
+	}
+
+	ret = port_bridge_txmac_set(DEV_ID, SSDK_PORT_ID, 1);
+	if (ret) {
+		pr_err("force_sgmiiplus: failed to enable bridge TX MAC: %d\n",
+		       ret);
+		return ret;
+	}
+
+	pr_info("force_sgmiiplus: MAC data path enabled at 2500/full\n");
+	return 0;
+}
+
+static int force_sgmiiplus_program_mode(unsigned int mode,
+					unsigned int speed)
+{
+	unsigned int mode0;
+	unsigned int mode2;
+	int ret;
+
+	mode0 = dt_global_get_mac_mode(DEV_ID, 0);
+	mode2 = dt_global_get_mac_mode(DEV_ID, 2);
+
+	ret = dt_global_set_mac_mode(DEV_ID, UNIPHY_INDEX, mode);
+	if (ret) {
+		pr_err("force_sgmiiplus: global mode update failed: %d\n", ret);
+		return ret;
+	}
+
+	port5_clock_source_set();
+
+	ret = uniphy_mode_set(DEV_ID, UNIPHY_INDEX, mode);
+	if (ret) {
+		pr_err("force_sgmiiplus: uniphy mode update failed: %d\n", ret);
+		return ret;
+	}
+
+	ret = port_mux_mac_type_set(DEV_ID, SSDK_PORT_ID, mode0, mode, mode2);
+	if (ret) {
+		pr_err("force_sgmiiplus: vendor MAC/mux transition failed: %d\n",
+		       ret);
+		return ret;
+	}
+
+	port_speed_clock_set(DEV_ID, SSDK_PORT_ID, speed);
+	pr_info("force_sgmiiplus: vendor mode transition complete: mode=0x%x mac_type=%u speed=%u\n",
+		mode, port_mac_type_get(DEV_ID, SSDK_PORT_ID), speed);
+
+	return 0;
+}
+
+static int force_sgmiiplus_ensure_mode(bool *reapplied)
+{
+	unsigned int phy_mode = 0;
+	unsigned int global_mode;
+	unsigned int bmp;
+	unsigned int mac_type;
+	int port_mode;
+	bool force_mode;
+	bool bitmap_drift;
+	int ret;
+	int start_ret;
+
+	*reapplied = false;
+
+	ret = uniphy_phy_mode_get(DEV_ID, UNIPHY_INDEX, &phy_mode);
+	if (ret)
+		return ret;
+
+	ret = port_iface_mode_get(DEV_ID, SSDK_PORT_ID, &port_mode);
+	if (ret)
+		return ret;
+
+	global_mode = dt_global_get_mac_mode(DEV_ID, UNIPHY_INDEX);
+	force_mode = port_feature_get(DEV_ID, SSDK_PORT_ID,
+				      PHY_F_FORCE_INTERFACE_MODE) != 0;
+	bmp = port_bmp_get(DEV_ID);
+	mac_type = port_mac_type_get(DEV_ID, SSDK_PORT_ID);
+	bitmap_drift = (bmp & (1u << SSDK_PORT_ID)) != 0;
+
+	if ((phy_mode & UNIPHY_PHY_MODE_MASK) ==
+		    UNIPHY_PHY_MODE_SGMIIPLUS &&
+	    port_mode == PORT_MODE_SGMIIPLUS &&
+	    global_mode == SSDK_UNIPHY_SGMIIPLUS && force_mode &&
+	    mac_type == PORT_XGMAC_TYPE && !bitmap_drift) {
+		if (!recovery_sync_worker_stopped)
+			return 0;
+
+		ret = ssdk_mac_sw_sync_work_start(DEV_ID);
+		if (ret)
+			return ret;
+
+		recovery_sync_worker_stopped = false;
+		*reapplied = true;
+		pr_info("force_sgmiiplus: sync worker recovered after mode repair\n");
+		return 0;
+	}
+
+	pr_warn("force_sgmiiplus: mode drift detected: phy=0x%x port=0x%x global=0x%x force=%u mac=%u bitmap=0x%x; reasserting SGMII+\n",
+		phy_mode, port_mode, global_mode, force_mode ? 1 : 0,
+		mac_type, bmp);
+
+	ret = force_sgmiiplus_set_data_path(0);
+	if (ret)
+		return ret;
+	WRITE_ONCE(*link_cache, 0);
+
+	ret = ssdk_mac_sw_sync_work_stop(DEV_ID);
+	if (ret) {
+		pr_err("force_sgmiiplus: failed to stop sync worker during mode recovery: %d\n",
+		       ret);
+		return ret;
+	}
+	recovery_sync_worker_stopped = true;
+
+	bmp = port_bmp_get(DEV_ID);
+	port_bmp_set(DEV_ID, bmp & ~(1u << SSDK_PORT_ID));
+
+	ret = port_iface_mode_force(DEV_ID, SSDK_PORT_ID,
+				    PORT_MODE_SGMIIPLUS);
+	if (ret) {
+		pr_err("force_sgmiiplus: failed to restore forced port mode: %d\n",
+		       ret);
+		goto restart_worker;
+	}
+
+	ret = force_sgmiiplus_program_mode(SSDK_UNIPHY_SGMIIPLUS,
+					   SPEED_2500);
+	if (ret)
+		goto restart_worker;
+
+	msleep(1000);
+
+restart_worker:
+	start_ret = ssdk_mac_sw_sync_work_start(DEV_ID);
+	if (start_ret) {
+		pr_err("force_sgmiiplus: failed to restart sync worker during mode recovery: %d\n",
+		       start_ret);
+		if (!ret)
+			ret = start_ret;
+	} else {
+		recovery_sync_worker_stopped = false;
+	}
+	if (ret)
+		return ret;
+
+	*reapplied = true;
+	pr_info("force_sgmiiplus: SGMII+ mode restored after drift\n");
+	return 0;
+}
+
+static int force_sgmiiplus_sync_host_link(bool announce)
+{
+	unsigned int pcs_status = 0;
+	unsigned int host_link;
+	unsigned int old_link;
+	unsigned int old_speed;
+	unsigned int old_duplex;
+	bool update_required;
+	int ret;
+
+	ret = uniphy_status_get(DEV_ID, UNIPHY_INDEX, &pcs_status);
+	if (ret)
+		return ret;
+
+	host_link = (pcs_status & UNIPHY_PCS_LINK_BIT) ? 1 : 0;
+	old_link = READ_ONCE(*link_cache);
+	old_speed = READ_ONCE(*speed_cache);
+	old_duplex = READ_ONCE(*duplex_cache);
+	update_required = announce || old_link != host_link ||
+			  old_speed != SPEED_2500 ||
+			  old_duplex != SSDK_DUPLEX_FULL;
+
+	if (update_required) {
+		ret = force_sgmiiplus_set_data_path(host_link);
+		if (ret)
+			return ret;
+	}
+
+	WRITE_ONCE(*speed_cache, SPEED_2500);
+	WRITE_ONCE(*duplex_cache, SSDK_DUPLEX_FULL);
+	WRITE_ONCE(*link_cache, host_link);
+
+	if (announce || old_link != host_link)
+		pr_info("force_sgmiiplus: PCS status 0x%08x, host link %u -> %u\n",
+			pcs_status, old_link, host_link);
+
+	if (update_required)
+		force_sgmiiplus_notify_host_link(host_link);
+
+	return 0;
+}
+
+static int force_sgmiiplus_link_monitor(void *unused)
+{
+	bool mode_failed = false;
+	bool read_failed = false;
+	bool mode_reapplied;
+	int ret;
+
+	while (!kthread_should_stop()) {
+		ret = force_sgmiiplus_ensure_mode(&mode_reapplied);
+		if (ret) {
+			if (!mode_failed)
+				pr_err("force_sgmiiplus: hardware mode synchronization failed: %d\n",
+				       ret);
+			mode_failed = true;
+			goto sleep;
+		}
+		if (mode_failed) {
+			pr_info("force_sgmiiplus: hardware mode synchronization recovered\n");
+			mode_failed = false;
+		}
+
+		ret = force_sgmiiplus_sync_host_link(mode_reapplied);
+		if (ret && !read_failed) {
+			pr_err("force_sgmiiplus: host link synchronization failed: %d\n",
+			       ret);
+			read_failed = true;
+		} else if (!ret && read_failed) {
+			pr_info("force_sgmiiplus: PCS status reads recovered\n");
+			read_failed = false;
+		}
+
+sleep:
+		if (msleep_interruptible(LINK_MONITOR_INTERVAL_MS) &&
+		    kthread_should_stop())
+			break;
+	}
+
+	return 0;
+}
+
+static void force_sgmiiplus_restore_cache(void)
+{
+	if (!link_cache)
+		return;
+
+	WRITE_ONCE(*speed_cache, orig_speed);
+	WRITE_ONCE(*duplex_cache, orig_duplex);
+	WRITE_ONCE(*link_cache, orig_link);
+	pr_info("force_sgmiiplus: cache restored link=%u speed=%u duplex=%u\n",
+		orig_link, orig_speed, orig_duplex);
+}
+
+static int force_sgmiiplus_restore_interface(void)
+{
+	int ret = 0;
+	int err;
+
+	if (orig_force_interface_mode) {
+		err = port_iface_mode_force(DEV_ID, SSDK_PORT_ID,
+					    orig_port_iface_mode);
+	} else {
+		err = port_iface_mode_force(DEV_ID, SSDK_PORT_ID,
+					    PORT_INTERFACE_MODE_AUTO);
+		if (!err)
+			err = port_iface_mode_set_raw(DEV_ID, SSDK_PORT_ID,
+						      orig_port_iface_mode);
+	}
+	if (err) {
+		pr_err("force_sgmiiplus: failed to restore port mode: %d\n", err);
+		ret = err;
+	}
+
+	err = force_sgmiiplus_program_mode(orig_mac_mode, 1000);
+	if (err) {
+		pr_err("force_sgmiiplus: failed to restore vendor mode path: %d\n",
+		       err);
+		if (!ret)
+			ret = err;
+	}
+
+	return ret;
+}
 
 static int __init force_sgmiiplus_init(void)
 {
 	int ret;
+	int restore_ret;
 	unsigned int bmp;
 
 	uniphy_mode_set = (uniphy_mode_set_fn)kallsyms_lookup_name(
 		"adpt_hppe_uniphy_mode_set");
-	port_iface_mode_set = (port_iface_mode_set_fn)kallsyms_lookup_name(
+	port_iface_mode_force = (port_iface_mode_set_fn)kallsyms_lookup_name(
+		"adpt_hppe_port_interface_mode_set");
+	port_iface_mode_set_raw = (port_iface_mode_set_fn)kallsyms_lookup_name(
 		"_adpt_hppe_port_interface_mode_set");
+	port_iface_mode_get = (port_iface_mode_get_fn)kallsyms_lookup_name(
+		"adpt_hppe_port_interface_mode_get");
+	dt_global_get_mac_mode = (dt_global_get_mac_mode_fn)kallsyms_lookup_name(
+		"ssdk_dt_global_get_mac_mode");
 	dt_global_set_mac_mode = (dt_global_set_mac_mode_fn)kallsyms_lookup_name(
 		"ssdk_dt_global_set_mac_mode");
 	port_bmp_get = (port_bmp_get_fn)kallsyms_lookup_name(
 		"qca_ssdk_port_bmp_get");
 	port_bmp_set = (port_bmp_set_fn)kallsyms_lookup_name(
 		"qca_ssdk_port_bmp_set");
+	port_feature_get = (port_feature_get_fn)kallsyms_lookup_name(
+		"hsl_port_feature_get");
+	port_mux_mac_type_set = (port_mux_mac_type_set_fn)kallsyms_lookup_name(
+		"adpt_hppe_port_mux_mac_type_set");
+	port_mac_type_get = (port_mac_type_get_fn)kallsyms_lookup_name(
+		"qca_hppe_port_mac_type_get");
+	port5_clock_source_set = (port5_clock_source_set_fn)kallsyms_lookup_name(
+		"ssdk_uniphy_port5_clock_source_set");
+	port_speed_clock_set = (port_speed_clock_set_fn)kallsyms_lookup_name(
+		"adpt_hppe_gcc_port_speed_clock_set");
+	uniphy_status_get = (uniphy_status_get_fn)kallsyms_lookup_name(
+		"hppe_uniphy_channel0_input_output_6_get");
+	uniphy_phy_mode_get = (uniphy_phy_mode_get_fn)kallsyms_lookup_name(
+		"hppe_uniphy_phy_mode_ctrl_get");
+	priv_data_get = (priv_data_get_fn)kallsyms_lookup_name(
+		"ssdk_phy_priv_data_get");
+	link_notify = (link_notify_fn)kallsyms_lookup_name(
+		"ssdk_port_link_notify");
+	send_phy_event = (phy_event_fn)kallsyms_lookup_name(
+		"ubnt_send_phy_event");
+	port_txmac_set = (port_control_set_fn)kallsyms_lookup_name(
+		"adpt_hppe_port_txmac_status_set");
+	port_rxmac_set = (port_control_set_fn)kallsyms_lookup_name(
+		"adpt_hppe_port_rxmac_status_set");
+	port_bridge_txmac_set = (port_control_set_fn)kallsyms_lookup_name(
+		"adpt_hppe_port_bridge_txmac_set");
+	port_mac_speed_set = (port_control_set_fn)kallsyms_lookup_name(
+		"adpt_hppe_port_mac_speed_set");
+	port_mac_duplex_set = (port_control_set_fn)kallsyms_lookup_name(
+		"adpt_hppe_port_mac_duplex_set");
 
-	if (!uniphy_mode_set || !port_iface_mode_set || !dt_global_set_mac_mode ||
-	    !port_bmp_get || !port_bmp_set) {
+	if (!uniphy_mode_set || !port_iface_mode_force ||
+	    !port_iface_mode_set_raw || !port_iface_mode_get ||
+	    !dt_global_get_mac_mode || !dt_global_set_mac_mode ||
+	    !port_bmp_get || !port_bmp_set || !port_feature_get ||
+	    !port_mux_mac_type_set || !port_mac_type_get ||
+	    !port5_clock_source_set || !port_speed_clock_set ||
+	    !uniphy_status_get || !uniphy_phy_mode_get || !priv_data_get ||
+	    !port_txmac_set || !port_rxmac_set || !port_bridge_txmac_set ||
+	    !port_mac_speed_set || !port_mac_duplex_set) {
 		pr_err("force_sgmiiplus: kallsyms lookup failed\n");
 		return -ENOENT;
 	}
 
-	pr_info("force_sgmiiplus: resolved all symbols\n");
+	priv_addr = priv_data_get(DEV_ID);
+	if (!priv_addr) {
+		pr_err("force_sgmiiplus: SSDK private data unavailable\n");
+		return -ENODEV;
+	}
+
+	link_cache = (unsigned int *)(priv_addr + LINK_CACHE_BASE +
+				      (SSDK_PORT_ID - 1) * PORT_STRIDE);
+	speed_cache = (unsigned int *)(priv_addr + SPEED_CACHE_BASE +
+				       (SSDK_PORT_ID - 1) * PORT_STRIDE);
+	duplex_cache = (unsigned int *)(priv_addr + DUPLEX_CACHE_BASE +
+					(SSDK_PORT_ID - 1) * PORT_STRIDE);
+	orig_link = READ_ONCE(*link_cache);
+	orig_speed = READ_ONCE(*speed_cache);
+	orig_duplex = READ_ONCE(*duplex_cache);
 
 	orig_port_bmp = port_bmp_get(DEV_ID);
+	ret = port_iface_mode_get(DEV_ID, SSDK_PORT_ID,
+				  &orig_port_iface_mode);
+	if (ret) {
+		pr_err("force_sgmiiplus: failed to read port mode: %d\n", ret);
+		return ret;
+	}
+	orig_mac_mode = dt_global_get_mac_mode(DEV_ID, UNIPHY_INDEX);
+	orig_force_interface_mode =
+		port_feature_get(DEV_ID, SSDK_PORT_ID,
+				 PHY_F_FORCE_INTERFACE_MODE) != 0;
+	orig_port_mac_type = port_mac_type_get(DEV_ID, SSDK_PORT_ID);
+
+	pr_info("force_sgmiiplus: resolved symbols; original port_mode=0x%x mac_mode=0x%x mac_type=%u force=%u link=%u speed=%u duplex=%u\n",
+		orig_port_iface_mode, orig_mac_mode, orig_port_mac_type,
+		orig_force_interface_mode ? 1 : 0,
+		orig_link, orig_speed, orig_duplex);
+
+	ret = ssdk_mac_sw_sync_work_stop(DEV_ID);
+	if (ret) {
+		pr_err("force_sgmiiplus: failed to stop sync worker: %d\n", ret);
+		return ret;
+	}
+
 	bmp = orig_port_bmp & ~(1u << SSDK_PORT_ID);
-
-	ssdk_mac_sw_sync_work_stop(DEV_ID);
-
 	port_bmp_set(DEV_ID, bmp);
 	pr_info("force_sgmiiplus: port bitmap 0x%x -> 0x%x (port %d excluded)\n",
 		orig_port_bmp, bmp, SSDK_PORT_ID);
 
-	ret = uniphy_mode_set(DEV_ID, UNIPHY_INDEX, SSDK_UNIPHY_SGMIIPLUS);
-	if (ret != 0) {
-		pr_err("force_sgmiiplus: uniphy_mode_set failed: %d\n", ret);
-		port_bmp_set(DEV_ID, orig_port_bmp);
-		ssdk_mac_sw_sync_work_start(DEV_ID);
-		return ret;
+	/*
+	 * Use the public setter, not only the raw bookkeeping setter. It marks
+	 * PHY_F_FORCE_INTERFACE_MODE, so SFP EEPROM auto-detection cannot switch
+	 * this port back to 1000BASE-X if a later service restores the bitmap.
+	 */
+	ret = port_iface_mode_force(DEV_ID, SSDK_PORT_ID,
+				    PORT_MODE_SGMIIPLUS);
+	if (ret) {
+		pr_err("force_sgmiiplus: forced port mode failed: %d\n", ret);
+		goto restore;
 	}
-	pr_info("force_sgmiiplus: uniphy%d set to SGMII+ 2.5G\n", UNIPHY_INDEX);
 
-	port_iface_mode_set(DEV_ID, SSDK_PORT_ID, PORT_MODE_SGMIIPLUS);
-	dt_global_set_mac_mode(DEV_ID, UNIPHY_INDEX, SSDK_UNIPHY_SGMIIPLUS);
+	ret = force_sgmiiplus_set_data_path(0);
+	if (ret)
+		goto restore;
+	WRITE_ONCE(*link_cache, 0);
+
+	ret = force_sgmiiplus_program_mode(SSDK_UNIPHY_SGMIIPLUS,
+					   SPEED_2500);
+	if (ret)
+		goto restore;
+	pr_info("force_sgmiiplus: uniphy%d set to SGMII+ 2.5G\n",
+		UNIPHY_INDEX);
 
 	msleep(1000);
-	ssdk_mac_sw_sync_work_start(DEV_ID);
-	pr_info("force_sgmiiplus: loop restarted (port %d excluded)\n", SSDK_PORT_ID);
+	ret = ssdk_mac_sw_sync_work_start(DEV_ID);
+	if (ret) {
+		pr_err("force_sgmiiplus: failed to restart sync worker: %d\n", ret);
+		goto restore;
+	}
+	pr_info("force_sgmiiplus: loop restarted (port %d excluded, interface mode forced)\n",
+		SSDK_PORT_ID);
 
-	/* Update SSDK SFP PHY speed cache so ethtool/sysfs/UDAPI report 2500 */
-	{
-		priv_data_get_fn get_priv;
-		phy_event_fn send_phy_event;
-		link_notify_fn notify;
-		unsigned int *sp, *dp;
-
-		get_priv = (priv_data_get_fn)
-			kallsyms_lookup_name("ssdk_phy_priv_data_get");
-		if (get_priv)
-			priv_addr = get_priv(DEV_ID);
-
-		if (priv_addr) {
-			sp = (unsigned int *)(priv_addr + SPEED_CACHE_BASE +
-					     (SSDK_PORT_ID - 1) * PORT_STRIDE);
-			dp = (unsigned int *)(priv_addr + DUPLEX_CACHE_BASE +
-					     (SSDK_PORT_ID - 1) * PORT_STRIDE);
-			orig_speed = *sp;
-			orig_duplex = *dp;
-			*sp = SPEED_2500;
-			*dp = DUPLEX_FULL;
-			pr_info("force_sgmiiplus: speed cache %u -> %u\n",
-				orig_speed, SPEED_2500);
-		}
-
-		notify = (link_notify_fn)
-			kallsyms_lookup_name("ssdk_port_link_notify");
-		if (notify)
-			notify(SSDK_PORT_ID, 1, LINK_NOTIFY_SPEED_2500, 1);
-
-		send_phy_event = (phy_event_fn)
-			kallsyms_lookup_name("ubnt_send_phy_event");
-		if (send_phy_event)
-			send_phy_event(SSDK_PORT_ID);
-
-		/* Trigger RTM_NEWLINK so UDAPI re-reads ethtool.
-		 * Delayed 2s for PHY state machine to copy cache into
-		 * phydev->speed. UMH_NO_WAIT so module init returns
-		 * immediately — doesn't block the dsmp event loop. */
-		{
-			static char *argv[] = {
-				"/bin/sh", "-c",
-				"sleep 2 && ip link set eth6 alias x && ip link set eth6 alias ''",
-				NULL
-			};
-			static char *envp[] = { "PATH=/sbin:/bin", NULL };
-
-			call_usermodehelper(argv[0], argv, envp,
-					   UMH_NO_WAIT);
-		}
-		pr_info("force_sgmiiplus: speed reporting updated\n");
+	ret = force_sgmiiplus_sync_host_link(true);
+	if (ret) {
+		pr_err("force_sgmiiplus: initial host link synchronization failed: %d\n",
+		       ret);
+		goto restore;
 	}
 
+	link_monitor_task = kthread_run(force_sgmiiplus_link_monitor, NULL,
+					"sgmiiplus-link");
+	if (IS_ERR(link_monitor_task)) {
+		ret = PTR_ERR(link_monitor_task);
+		link_monitor_task = NULL;
+		pr_err("force_sgmiiplus: failed to start link monitor: %d\n",
+		       ret);
+		goto restore;
+	}
+
+	pr_info("force_sgmiiplus: PCS link monitor started; PON RX_LOS ignored\n");
+
 	return 0;
+
+restore:
+	if (link_monitor_task) {
+		kthread_stop(link_monitor_task);
+		link_monitor_task = NULL;
+	}
+	/*
+	 * The worker was restarted before initial link synchronization. Stop it
+	 * again before rollback so it cannot observe or rewrite half-restored
+	 * interface and mux state.
+	 */
+	restore_ret = ssdk_mac_sw_sync_work_stop(DEV_ID);
+	if (restore_ret)
+		pr_err("force_sgmiiplus: failed to stop worker during rollback: %d\n",
+		       restore_ret);
+	restore_ret = force_sgmiiplus_restore_interface();
+	force_sgmiiplus_restore_cache();
+	port_bmp_set(DEV_ID, orig_port_bmp);
+	if (ssdk_mac_sw_sync_work_start(DEV_ID))
+		pr_err("force_sgmiiplus: failed to restart worker during rollback\n");
+	if (!ret)
+		ret = restore_ret;
+	return ret;
 }
 
 static void __exit force_sgmiiplus_exit(void)
 {
-	if (!uniphy_mode_set)
-		return;
+	int ret;
 
-	if (priv_addr) {
-		unsigned int *sp = (unsigned int *)(priv_addr + SPEED_CACHE_BASE +
-						   (SSDK_PORT_ID - 1) * PORT_STRIDE);
-		unsigned int *dp = (unsigned int *)(priv_addr + DUPLEX_CACHE_BASE +
-						   (SSDK_PORT_ID - 1) * PORT_STRIDE);
-		*sp = orig_speed;
-		*dp = orig_duplex;
-		pr_info("force_sgmiiplus: speed cache restored to %u\n", orig_speed);
+	if (link_monitor_task) {
+		kthread_stop(link_monitor_task);
+		link_monitor_task = NULL;
+		pr_info("force_sgmiiplus: PCS link monitor stopped\n");
 	}
 
-	ssdk_mac_sw_sync_work_stop(DEV_ID);
+	ret = ssdk_mac_sw_sync_work_stop(DEV_ID);
+	if (ret)
+		pr_err("force_sgmiiplus: failed to stop worker during unload: %d\n",
+		       ret);
 
-	uniphy_mode_set(DEV_ID, UNIPHY_INDEX, SSDK_UNIPHY_SGMII_CH0);
+	force_sgmiiplus_restore_interface();
+	force_sgmiiplus_restore_cache();
+	port_bmp_set(DEV_ID, orig_port_bmp);
 
-	if (port_iface_mode_set)
-		port_iface_mode_set(DEV_ID, SSDK_PORT_ID, ORIG_PORT_IFACE_MODE);
-	dt_global_set_mac_mode(DEV_ID, UNIPHY_INDEX, ORIG_MAC_MODE);
+	ret = ssdk_mac_sw_sync_work_start(DEV_ID);
+	if (ret)
+		pr_err("force_sgmiiplus: failed to restart worker during unload: %d\n",
+		       ret);
 
-	if (port_bmp_set)
-		port_bmp_set(DEV_ID, orig_port_bmp);
-
-	ssdk_mac_sw_sync_work_start(DEV_ID);
-	pr_info("force_sgmiiplus: reverted, loop restarted with full bitmap 0x%x\n",
-		orig_port_bmp);
+	pr_info("force_sgmiiplus: reverted port_mode=0x%x mac_mode=0x%x force=%u bitmap=0x%x\n",
+		orig_port_iface_mode, orig_mac_mode,
+		orig_force_interface_mode ? 1 : 0, orig_port_bmp);
 }
 
 module_init(force_sgmiiplus_init);

--- a/scripts/20-sfp-sgmiiplus.sh
+++ b/scripts/20-sfp-sgmiiplus.sh
@@ -1,26 +1,15 @@
 #!/bin/sh
 # 20-sfp-sgmiiplus.sh: Force 2nd SFP+ port (eth6 / Port 7) to SGMII+ 2.5G
 #
-# Waits for the SFP to establish a 1G link, then loads a kernel module that
-# switches uniphy1 from SGMII 1G to SGMII+ 2.5G. The wait avoids a boot-order
-# race with SFPs that need time to configure their SerDes (e.g., Zyxel PMG3000
-# takes ~15s after boot to fire its 2.5G override). If no 1G link appears
-# within the timeout, the module loads anyway — this handles SFPs that are
-# hard-locked at 2.5G and can't establish a 1G link without the host matching.
+# Loads the kernel module as soon as qca_ssdk is available. The module forces
+# uniphy1 from SGMII 1G to SGMII+ 2.5G, excludes eth6 from the SSDK MAC-sync
+# bitmap, and continuously verifies the physical UniPHY mode. If a later SFP
+# event restores native SGMII, the module disables the data path, reasserts
+# SGMII+, and resynchronizes PCS and MAC state.
 #
-# The boot-time mode set does not always commit: uniphy1 can stay at 125 MHz
-# even though insmod succeeded, and early in boot a set that did commit can
-# still be reverted up to ~35s later. Which boots are affected is timing-
-# dependent, so a given firmware and SFP can boot cleanly and fail on the next
-# try. The script retries up to five times, restoring stock SGMII 1G between
-# attempts, and verifies that the 312.5 MHz clock holds for 45s before
-# declaring success.
-#
-# The module bypasses the SSDK's SFP EEPROM validation by calling the uniphy
-# mode set function directly. The SSDK's MAC sync polling loop re-reads the
-# SFP EEPROM every ~12s and would revert the 2.5G change. The module (v3+)
-# excludes eth6 from the polling loop's port bitmap and restarts it — the loop
-# continues to run for all other ports, so eth5 link recovery is unaffected.
+# A runtime-directory lock prevents duplicate background instances. The module
+# is loaded exactly once: this script never unloads or retries a live module.
+# The self-healing monitor owns recovery after a successful insmod.
 #
 # WARNING: This targets eth6 / Port 7 (the 2nd SFP+ port) ONLY.
 # For eth5 / Port 6, use 19-sfp-sgmiiplus-eth5.sh instead.
@@ -34,20 +23,28 @@ MODULE_DIR="/data/sfp-sgmiiplus"
 MODULE_NAME="force_uniphy1_sgmiiplus"
 MODULE_FILE="${MODULE_DIR}/${MODULE_NAME}.ko"
 CLOCK_PATH="/sys/kernel/debug/clk/uniphy1_gcc_tx_clk/clk_rate"
-IFACE="eth6"
-CARRIER_TIMEOUT=90
-MAX_ATTEMPTS=5
-HOLD_SECS=45
+LOCK_DIR="/run/${SCRIPT_NAME}.lock"
+QCA_SSDK_TIMEOUT=90
+VERIFY_TIMEOUT=60
+VERIFY_HOLD_SECS=15
 
 log() {
     echo "$(date '+%Y-%m-%d %H:%M:%S') - $1" >> "${LOG_FILE}"
 }
 
-# Re-exec in background so on_boot.d doesn't block waiting for carrier
+# Re-exec in background so on_boot.d doesn't block qca_ssdk wait or verification
 if [ "$1" != "--bg" ]; then
     nohup "$0" --bg >/dev/null 2>&1 &
     exit 0
 fi
+
+# ─── Single-instance guard ───
+
+if ! mkdir "${LOCK_DIR}" 2>/dev/null; then
+    log "Another ${SCRIPT_NAME} loader is already active. Nothing to do."
+    exit 0
+fi
+trap 'rmdir "${LOCK_DIR}" 2>/dev/null' EXIT INT TERM
 
 # ─── Sanity checks ───
 
@@ -56,143 +53,79 @@ if [ ! -f "${MODULE_FILE}" ]; then
     exit 1
 fi
 
-if lsmod | grep -q "${MODULE_NAME}"; then
-    log "Module ${MODULE_NAME} already loaded. Nothing to do."
-    exit 0
-fi
-
-if ! lsmod | grep -q "qca_ssdk"; then
-    log "ERROR: qca-ssdk.ko not loaded. Cannot proceed."
-    exit 1
-fi
-
-# ─── Wait for 1G carrier or timeout ───
-
 elapsed=0
-while [ $elapsed -lt $CARRIER_TIMEOUT ]; do
-    carrier=$(cat /sys/class/net/${IFACE}/carrier 2>/dev/null)
-    if [ "$carrier" = "1" ]; then
-        log "${IFACE} has carrier after ${elapsed}s — loading module"
+while [ ${elapsed} -lt ${QCA_SSDK_TIMEOUT} ]; do
+    if lsmod | grep -q "^qca_ssdk "; then
         break
     fi
     sleep 2
     elapsed=$((elapsed + 2))
 done
 
-if [ "$carrier" != "1" ]; then
-    log "${IFACE} no carrier after ${CARRIER_TIMEOUT}s — loading module anyway (SFP may be hard-locked at 2.5G)"
+if ! lsmod | grep -q "^qca_ssdk "; then
+    log "ERROR: qca_ssdk did not load within ${QCA_SSDK_TIMEOUT}s"
+    exit 1
 fi
 
-# ─── Load and verify module ───
+if lsmod | grep -q "^${MODULE_NAME} "; then
+    log "Module ${MODULE_NAME} already loaded. Nothing to do."
+    exit 0
+fi
 
-BEFORE_CLOCK=""
+# ─── Load once; the module owns recovery ───
+
 if [ -f "${CLOCK_PATH}" ]; then
     BEFORE_CLOCK=$(cat "${CLOCK_PATH}")
     log "Clock rate before: ${BEFORE_CLOCK} Hz"
 fi
 
-attempt=1
+log "Loading ${MODULE_NAME}..."
+insmod "${MODULE_FILE}" 2>> "${LOG_FILE}"
+RET=$?
+
+if [ ${RET} -ne 0 ]; then
+    log "ERROR: insmod failed with exit code ${RET}"
+    exit 1
+fi
+
+if ! lsmod | grep -q "^${MODULE_NAME} "; then
+    log "ERROR: Module not present after successful insmod"
+    exit 1
+fi
+
+if [ ! -f "${CLOCK_PATH}" ]; then
+    log "WARNING: ${CLOCK_PATH} not found; module is loaded but clock rate cannot be verified"
+    log "Module loaded successfully"
+    log "Done"
+    exit 0
+fi
+
+elapsed=0
+held=0
 verified=0
-
-while [ $attempt -le $MAX_ATTEMPTS ]; do
-    log "Loading ${MODULE_NAME} (attempt ${attempt}/${MAX_ATTEMPTS})..."
-
-    insmod "${MODULE_FILE}" 2>> "${LOG_FILE}"
-    RET=$?
-
-    if [ ${RET} -ne 0 ]; then
-        log "ERROR: insmod failed with exit code ${RET}"
-        exit 1
-    fi
-
-    # Give the mode set sequence time to complete (~300ms PLL relock + calibration)
-    sleep 1
-
-    if [ ! -f "${CLOCK_PATH}" ]; then
-        log "WARNING: ${CLOCK_PATH} not found, cannot verify clock rate"
-        verified=1
-        break
-    fi
-
-    AFTER_CLOCK=$(cat "${CLOCK_PATH}")
-    log "Clock rate after attempt ${attempt}: ${AFTER_CLOCK} Hz"
-
-    # Clock is the success criterion, not carrier, so no-link 2.5G SFPs work.
+while [ ${elapsed} -lt ${VERIFY_TIMEOUT} ]; do
+    AFTER_CLOCK=$(cat "${CLOCK_PATH}" 2>/dev/null)
     if [ "${AFTER_CLOCK}" = "312500000" ]; then
-        log "Clock reached 312500000 Hz; verifying it holds for ${HOLD_SECS}s"
-        held=0
-        while [ $held -lt $HOLD_SECS ]; do
-            sleep 5
-            held=$((held + 5))
-            AFTER_CLOCK=$(cat "${CLOCK_PATH}" 2>/dev/null)
-            if [ "${AFTER_CLOCK}" != "312500000" ]; then
-                break
-            fi
-        done
-
-        if [ "${AFTER_CLOCK}" = "312500000" ]; then
-            log "Verified: uniphy1 running at 312.5 MHz (SGMII+ 2.5G) and held for ${HOLD_SECS}s"
+        held=$((held + 1))
+        if [ ${held} -ge ${VERIFY_HOLD_SECS} ]; then
             verified=1
             break
         fi
-
-        log "WARNING: Attempt ${attempt} clock reverted to ${AFTER_CLOCK} Hz after ${held}s of holding"
     else
-        log "WARNING: Attempt ${attempt} expected 312500000 Hz, got ${AFTER_CLOCK} Hz"
+        held=0
     fi
 
-    log "Removing ${MODULE_NAME} to restore stock SGMII 1G before retry"
-    rmmod "${MODULE_NAME}" 2>> "${LOG_FILE}"
-    RET=$?
-
-    if [ ${RET} -ne 0 ]; then
-        log "ERROR: rmmod failed with exit code ${RET}"
-        exit 1
-    fi
-
-    elapsed=0
-    carrier=""
-    while [ $elapsed -lt 30 ]; do
-        carrier=$(cat /sys/class/net/${IFACE}/carrier 2>/dev/null)
-        if [ "$carrier" = "1" ]; then
-            log "${IFACE} stock 1G carrier recovered after ${elapsed}s"
-            break
-        fi
-        sleep 2
-        elapsed=$((elapsed + 2))
-    done
-
-    if [ "$carrier" != "1" ]; then
-        log "WARNING: ${IFACE} stock 1G carrier did not recover after 30s; continuing anyway"
-    fi
-
-    if [ $attempt -lt $MAX_ATTEMPTS ]; then
-        backoff=$((attempt * 5))
-        log "Retrying after ${backoff}s backoff"
-        sleep $backoff
-    fi
-
-    attempt=$((attempt + 1))
+    sleep 1
+    elapsed=$((elapsed + 1))
 done
 
-if [ $verified -ne 1 ]; then
-    if lsmod | grep -q "${MODULE_NAME}"; then
-        rmmod "${MODULE_NAME}" 2>> "${LOG_FILE}"
-        RET=$?
-        if [ ${RET} -ne 0 ]; then
-            log "ERROR: final rmmod failed with exit code ${RET}"
-            exit 1
-        fi
-    fi
-    log "ERROR: 2.5G mode did not stick after ${MAX_ATTEMPTS} attempts; ${IFACE} was left in stock SGMII 1G state so the link still works at 1G"
-    exit 1
-fi
-
-if lsmod | grep -q "${MODULE_NAME}"; then
-    log "Module loaded successfully"
+if [ ${verified} -eq 1 ]; then
+    log "Verified: uniphy1 held at 312.5 MHz (SGMII+ 2.5G) for ${VERIFY_HOLD_SECS}s"
 else
-    log "ERROR: Module not present after insmod"
+    log "ERROR: uniphy1 did not hold 312.5 MHz for ${VERIFY_HOLD_SECS}s within ${VERIFY_TIMEOUT}s"
+    log "Module remains loaded; automatic unload is intentionally disabled"
     exit 1
 fi
 
+log "Module loaded successfully"
 log "Done"


### PR DESCRIPTION
## Summary

- keep eth6 in the forced SGMII+/XGMAC configuration when a later SFP event rewrites UniPHY or SSDK state
- move retry/recovery ownership into the kernel module; the boot loader waits for qca_ssdk, loads once, and checks the 312.5 MHz clock
- document the current UniPHY1 recovery path and symbol dependencies

## Validation

- `sh -n scripts/20-sfp-sgmiiplus.sh`
- `git diff --check`

A target-kernel module build and live gateway test were not run here: the required UCG-Fiber/UXG-Fiber kernel source, matching config, ARM64 cross-compiler, and hardware are unavailable on this host. The module should be rebuilt from this source and exercised on a supported gateway before deployment.

## Scope

The locally rebuilt `force_uniphy1_sgmiiplus.ko` is intentionally not included; this PR contains source, loader, and documentation only.